### PR TITLE
Add support for generations in collector

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,3 @@
-//
-// Store Spark Core devices raw events
-//
 var Promise = require('promise');
 var http = require('https');
 var spark = require('spark');
@@ -12,7 +9,7 @@ const eventmodule = require('./event.js');
 var config = require('./config.json');
 var accessToken = config.accessToken;
 
-const eventDB = eventmodule.EventDatabase(db);
+const eventDB = new eventmodule.EventDatabase(db);
 const CommandHandler = require('./command.js').CommandHandler(db);
 
 var app = express();
@@ -22,8 +19,11 @@ app.use(express.static(path.join(__dirname, 'public')));
 app.use('/', express.static(path.join(__dirname, 'index.html')));
 app.get('/device/:id', function(req, res) {
   db.serialize(function() {
-    var serial_no = req.query.since;
-    db.all("select * from raw_events where device_id = ? and serial_no > ?", [req.params.id, serial_no], function(err, rows) {
+    var generationId = req.query.generation;
+    var serialNo = req.query.since;
+    var sql = "select * from raw_events where device_id = ? and generation_id = ? and serial_no > ?";
+    var params = [req.params.id, generationId, serialNo];
+    db.all(sql, params, function(err, rows) {
       if (err) {
         console.log(err);
         return res.send(500, err);
@@ -47,7 +47,7 @@ spark.login({
 }).then(
   function(token) {
     console.log('Login completed. Token: ', token);
-    requestReplay();
+    requestAllDeviceReplay();
     console.log('Connecting to event stream.');
     spark.getEventStream(false, 'mine', function(event, err) {
       if (err) {
@@ -60,7 +60,7 @@ spark.login({
           eventDB.handleEvent(event);
         }
       } catch (exception) {
-        console.log("Exception: " + exception + "\n" + exception.stack);
+        console.error("Exception: " + exception + "\n" + exception.stack);
       }
     });
   },
@@ -69,20 +69,41 @@ spark.login({
   }
 );
 
-function requestReplay() {
-  db.each("select device_id, max(serial_no) as serial_no from raw_events group by device_id", function(err, row) {
+function requestAllDeviceReplay() {
+  var sql = "select raw_events.device_id as device_id, raw_events.generation_id as generation_id, max(raw_events.serial_no) as serial_no from raw_events, (select device_id, max(generation_id) as generation_id from raw_events) as gens where raw_events.device_id = gens.device_id and raw_events.generation_id = gens.generation_id";
+  db.each(sql, function(err, row) {
     if (err) {
       throw err;
+    } else if (row.device_id == null) {
+      // Ignoring empty row returned by sqlite aggregate function on empty result.
+      console.log("No devices to request a replay from.");
+    } else if (typeof row.generation_id === "undefined") {
+      console.error("Got undefined generation for device %s. Don't know what to request. Waiting for new events. POSSIBLE DATA LOSS!", row.device_id);
+    } else {
+      requestDeviceReplay(row.device_id, row.generation_id, row.serial_no + 1);
     }
-    console.log("Requesting replay on " + row.device_id);
-    spark.getDevice(row.device_id, function(err, device) {
-      device.callFunction('replay', row.serial_no + 1).then(function(err, data) {
-        if (err) {
-          console.error('Replay request failed:', err);
+  });
+}
+
+function requestDeviceReplay(deviceId, generationId, serialNo) {
+  console.log("Requesting replay on %s at %s,%s", deviceId, generationId, serialNo);
+  spark.getDevice(deviceId, function(err, device) {
+    device.callFunction('replay', "" + serialNo + ", " + generationId, function(err, data) {
+      // Return codes:
+      //   0  Success
+      //  -1  Failure
+      //  -2  A replay is already in progress
+      // -99  Invalid generation ID
+      if (err) {
+        console.error("Replay request failed: '%s' on %s at %s,%s with code %s. EVENTS MAY BE LOST! Ensure the device is online, then restart the collector to request a new replay.", err, deviceId, generationId, serialNo, data.return_value);
+      } else {
+        if (data.return_value == 0) {
+          console.log('Replay request successful: ', data);
         } else {
-          console.log('Replay request successful:', data);
+          console.log('Replay request refused by %s at %s,%s with code %s. EVENTS MAY BE LOST! Waiting for events.', deviceId, generationId, serialNo, data.return_value);
+          requestReplay(deviceId, data.return_value, 0);
         }
-      });
+      }
     });
   });
 }

--- a/command.js
+++ b/command.js
@@ -1,29 +1,41 @@
 exports.CommandHandler = function(db) {
   return {
-    // format: { "command" : "query", "device": "device-id", "after": 0 }
+    // format: { "command" : "query", "device": "device-id", "generation" : 0, "after": 0 }
     "onCommand": function(command, connection) {
       if (command.command = "query") {
         db.serialize(function() {
-          if (command.after != undefined && command.device == undefined) {
+          var hasDeviceParam = (typeof command.device !== "undefined");
+          var hasGenerationParam = (typeof command.generation !== "undefined");
+          var hasAfterParam = (typeof command.after !== "undefined");
+          if (hasAfterParam && !hasDeviceParam) {
             connection.sendUTF(JSON.stringify({
-              "error": "parameter 'device' is mandatory with 'after'"
+              "error": "parameter 'device' is mandatory with 'after' parameter"
+            }));
+          }
+          if (hasAfterParam && !hasGenerationParam) {
+            connection.sendUTF(JSON.stringify({
+              "error": "parameter 'generation' is mandatory with 'after' parameter"
             }));
           }
           var sql = "select * from raw_events";
           var params = [];
-          if (command.device != undefined) {
+          if (hasDeviceParam) {
             sql = sql + " where device_id = ?";
             params.push(command.device);
           }
-          if (command.after != undefined) {
+          if (hasAfterParam) {
             sql = sql + " and serial_no > ?";
             params.push(command.after);
+          }
+          if (hasGenerationParam) {
+            sql = sql + " and generation_id = ?";
+            params.push(command.generation);
           }
           db.all(sql, params, function(err, rows) {
             if (err) {
               console.log(err);
               connection.sendUTF(JSON.stringify({
-                "error": "parameter 'device' is mandatory with 'after'"
+                "error": err
               }));
               return;
             }

--- a/schema.sql
+++ b/schema.sql
@@ -2,5 +2,6 @@
    device_id varchar(24),
    published_at timestamp,
    raw_data text,
+   generation_id integer,
    serial_no integer
 );

--- a/test/test.js
+++ b/test/test.js
@@ -5,7 +5,10 @@ var db = {
     callback.call(this);
   },
   "run": function(sql, params) {
-    console.log("Running: " + sql + " " + params);
+    console.log("Running: %s %s", sql, params);
+  },
+  "get": function(sql, params, callback) {
+    console.log("Getting: %s %s", sql, params);
   },
   "all": function(sql, params, callback) {
     console.log("Query: " + sql + " [" + params + "]");
@@ -19,8 +22,9 @@ var db = {
   }
 }
 
-const EventDatabase = require('../event.js').EventDatabase(db);
+const EventDatabase = require('../event.js').EventDatabase;
 const CommandHandler = require('../command.js').CommandHandler(db);
+var database = new EventDatabase(db);
 
 exports['test String#length'] = function() {
   assert.equal(6, 'foobar'.length);
@@ -34,7 +38,7 @@ exports['test handleEvent#normal'] = function() {
     "coreid": "1f003f000747343337373738",
     "name": "brunelle/live/sonde/BLAH/Distance"
   };
-  EventDatabase.handleEvent(event, db);
+  database.handleEvent(event, db);
 }
 
 exports['test handleEvent#replay'] = function() {
@@ -45,7 +49,7 @@ exports['test handleEvent#replay'] = function() {
     "coreid": "1f003f000747343337373738",
     "name": "brunelle/replay/sonde/BLAH/Distance"
   };
-  EventDatabase.handleEvent(event, db);
+  database.handleEvent(event, db);
 }
 
 exports['test handleEvent#started'] = function() {
@@ -56,7 +60,7 @@ exports['test handleEvent#started'] = function() {
     "coreid": "3a0037000c47343233323032",
     "name": "spark/flash/status"
   };
-  EventDatabase.handleEvent(event);
+  database.handleEvent(event);
 }
 
 exports['test handleEvent#failed'] = function() {
@@ -67,7 +71,7 @@ exports['test handleEvent#failed'] = function() {
     "coreid": "3a0037000c47343233323032",
     "name": "spark/flash/status"
   };
-  EventDatabase.handleEvent(event);
+  database.handleEvent(event);
 }
 
 exports['test handleEvent#online'] = function() {
@@ -78,7 +82,7 @@ exports['test handleEvent#online'] = function() {
     "coreid": "3a0037000c47343233323032",
     "name": "spark/status"
   };
-  EventDatabase.handleEvent(event);
+  database.handleEvent(event);
 }
 
 exports['test onEvent'] = function() {
@@ -89,10 +93,10 @@ exports['test onEvent'] = function() {
     "coreid": "1f003f000747343337373738",
     "name": "brunelle/live/sonde/BLAH/Distance"
   };
-  EventDatabase.onEvent(function(evt) {
+  database.onEvent(function(evt) {
     console.log("onEvent called: " + JSON.stringify(evt));
   });
-  EventDatabase.handleEvent(event);
+  database.handleEvent(event);
 }
 
 exports.testHandleCommand = function() {
@@ -104,6 +108,7 @@ exports.testHandleCommand = function() {
   var command = {
     "command": "query",
     "device": "device-id",
+    "generation": 0,
     "after": 0
   };
   CommandHandler.onCommand(command, connection);


### PR DESCRIPTION
- When requesting a replay, send the current known generation ID, allowing
  the device to refuse the replay, as the serial number is now invalid.
- When a client requests events since a serial number, require a generation ID,
  and only send events for the requested generation.
- Implement check for duplicate events, and ignore (and log) them.

Unfortunately, unit tests are pretty thin.